### PR TITLE
change to a static url instead of the routing API

### DIFF
--- a/ttfb-timing/ttfb_collector.py
+++ b/ttfb-timing/ttfb_collector.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 """measure http time to first byte (ttfb) latency for cdn hosted videos"""
 
-import json
 import time
 from timeit import default_timer
 import urllib2
@@ -24,29 +23,6 @@ def log_success(human_time, epoch, url, ttfb):
     with open(RESULTS, 'a') as f:
         f.write('{}\n'.format(msg))
     print(msg)
-
-
-def get_xuetang_api_url(url):
-    human_time = time.strftime('%Y-%m-%d %H:%M:%S', time.gmtime())
-    epoch = time.time()
-    try:
-        resp = urllib2.urlopen(url)
-        data = resp.read()
-        resp.close()
-    except urllib2.HTTPError as e:
-        log_error(human_time, epoch, url, e.code)
-        source_url = None
-    except urllib2.URLError as e:
-        log_error(human_time, epoch, url, e.reason)
-        source_url = None
-    else:
-        try:
-            json_data = json.loads(data)
-            source_url = json_data[u'sources'][0]
-        except Exception as e:
-            log_error(human_time, epoch, url, e)
-            source_url = None
-    return source_url
 
 
 def get_ttfb(url):
@@ -72,10 +48,7 @@ if __name__ == '__main__':
         urls = []
         urls.append('http://video.study.163.com/edu-video/nos/mp4/2014/06/23/460097_hd.mp4')
         urls.append('http://d2f1egay8yehza.cloudfront.net/TSGCMATH/TSGCMATHT314-V000400_DTH.mp4')
-        lookup_url = 'http://api.xuetangx.com/edx/video?s3_url=https://s3.amazonaws.com/edx-course-videos/mit-600x/M-600X-FA12-L3-Intro_100.mp4'
-        video_url = get_xuetang_api_url(lookup_url)
-        if video_url is not None:
-            urls.append(video_url)
+        urls.append('http://www.xuetangx.com//course-intro?D82C7AACFA056C939C33DC5901307461')
         for url in urls:
             get_ttfb(url)
         time.sleep(TIME_INTERVAL)


### PR DESCRIPTION
no longer using the XuetangX routing/lookup API to get a video URL... just using a static URL hosted on XuetangX CDN.

/cc @alawibaba 
